### PR TITLE
fix: users cannot re-accept invites

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,19 +3,19 @@
     "*.css": "tailwindcss"
   },
   "[javascript]": {
-    "editor.defaultFormatter": "biomejs.biome"
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "[typescript]": {
-    "editor.defaultFormatter": "biomejs.biome"
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "[javascriptreact]": {
-    "editor.defaultFormatter": "biomejs.biome"
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "[typescriptreact]": {
-    "editor.defaultFormatter": "biomejs.biome"
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "[json]": {
-    "editor.defaultFormatter": "biomejs.biome"
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {

--- a/src/lib/server/invites.ts
+++ b/src/lib/server/invites.ts
@@ -7,14 +7,27 @@ import { invite, user } from "$lib/server/db/schema";
 export async function createInvite(email: string, role: "user" | "admin" = "user", expiresInDays = 7) {
   if (await emailAlreadyRegistered(email)) {
     throw new Error(`${email} already has an account`);
-  } else if (await emailAlreadyInvited(email)) {
+  }
+
+  const existing = await emailAlreadyInvited(email);
+
+  // If the user was already invited, we only want to extend the expiration date if the invite was not yet used
+  // If it was used, we simply generate a new one. For security- and logging reasons, we do not want to reactivate the old one.
+  if (existing && !existing.usedAt) {
     const expiresAt = new Date(Date.now() + expiresInDays * 24 * 60 * 60 * 1000);
-    const [updated] = await db.update(invite).set({ expiresAt }).where(eq(invite.email, email)).returning();
+    const [updated] = await db
+      .update(invite)
+      .set({ expiresAt, usedAt: null })
+      .where(eq(invite.email, email))
+      .returning();
+
     return updated;
   }
+
   const token = randomUUID();
   const expiresAt = new Date(Date.now() + expiresInDays * 24 * 60 * 60 * 1000);
   const [created] = await db.insert(invite).values({ id: randomUUID(), email, token, role, expiresAt }).returning();
+
   return created;
 }
 
@@ -39,6 +52,10 @@ async function emailAlreadyRegistered(email: string) {
 }
 
 async function emailAlreadyInvited(email: string) {
-  const [existing] = await db.select({ id: invite.id }).from(invite).where(eq(invite.email, email));
+  const [existing] = await db
+    .select({ id: invite.id, usedAt: invite.usedAt })
+    .from(invite)
+    .where(eq(invite.email, email));
+
   return existing;
 }

--- a/src/lib/server/invites.ts
+++ b/src/lib/server/invites.ts
@@ -41,10 +41,6 @@ export async function consumeInvite(token: string) {
   await db.update(invite).set({ usedAt: new Date() }).where(eq(invite.token, token));
 }
 
-export async function deleteInviteByEmail(email: string) {
-  await db.delete(invite).where(eq(invite.email, email));
-}
-
 // Helper functions
 async function emailAlreadyRegistered(email: string) {
   const [existing] = await db.select({ id: user.id }).from(user).where(eq(user.email, email));

--- a/src/routes/(protected)/users/+page.server.ts
+++ b/src/routes/(protected)/users/+page.server.ts
@@ -7,7 +7,7 @@ import { auth } from "$lib/server/auth";
 import { db } from "$lib/server/db";
 import { session, user } from "$lib/server/db/schema";
 import { inviteEmail } from "$lib/server/email-templates";
-import { createInvite, deleteInviteByEmail } from "$lib/server/invites";
+import { createInvite } from "$lib/server/invites";
 import { sendEmail } from "$lib/server/mail";
 
 import type { Actions, PageServerLoad } from "./$types";
@@ -214,8 +214,6 @@ export const actions: Actions = {
       headers: event.request.headers,
       body: { userId },
     });
-
-    await deleteInviteByEmail(targetUser.email);
 
     return { message: m.users_delete_success({ name: targetUser.name }) };
   },


### PR DESCRIPTION
When a user was invited to the platform and then removed, they were not able to be re-added by inviting them again.