### PR TITLE
fix: form errors when providing default values

### DIFF
--- a/src/routes/(auth)/reset-password/+page.server.ts
+++ b/src/routes/(auth)/reset-password/+page.server.ts
@@ -19,7 +19,7 @@ export const load: PageServerLoad = async (event) => {
   }
 
   return {
-    form: await superValidate({ token }, zod(resetPasswordSchema)),
+    form: await superValidate({ token }, zod(resetPasswordSchema), { errors: false }),
   };
 };
 

--- a/src/routes/(auth)/signup/+page.server.ts
+++ b/src/routes/(auth)/signup/+page.server.ts
@@ -29,7 +29,7 @@ export const load: PageServerLoad = async (event) => {
   }
 
   return {
-    form: await superValidate({ token: invite.token }, zod(signupSchema)),
+    form: await superValidate({ token: invite.token }, zod(signupSchema), { errors: false }),
     email: invite.email,
   };
 };

--- a/src/routes/(protected)/licenses/+page.server.ts
+++ b/src/routes/(protected)/licenses/+page.server.ts
@@ -12,7 +12,7 @@ export const load: PageServerLoad = async () => {
   const products = await db.select({ id: product.id, name: product.name }).from(product);
   return {
     products,
-    form: await superValidate(zod(createLicenseSchema), { id: "create-license" }),
+    form: await superValidate({ usageVolume: 1 }, zod(createLicenseSchema), { id: "create-license", errors: false }),
   };
 };
 

--- a/src/routes/(protected)/products/+page.server.ts
+++ b/src/routes/(protected)/products/+page.server.ts
@@ -10,7 +10,10 @@ import type { PageServerLoad } from "./$types";
 
 export const load: PageServerLoad = async () => {
   return {
-    form: await superValidate(zod(createProductSchema), { id: "create-product" }),
+    form: await superValidate({ maxLicensesPerUser: 1 }, zod(createProductSchema), {
+      id: "create-product",
+      errors: false,
+    }),
   };
 };
 


### PR DESCRIPTION
There was an issue where a form shows validation error when loading the page for the first time. This was caused by providing partial default values (some fields in the form have default values, but not all). This is now fixed by ignoring all errors when first loading the form.

Additionally, I (re-)added default values for forms where it makes sense.

<img width="634" height="645" alt="image" src="https://github.com/user-attachments/assets/acd5fe92-36fd-4503-8699-435400617b1b" />
